### PR TITLE
Update exisiting Event service (Frontend)

### DIFF
--- a/web/src/Services/eventService.tsx
+++ b/web/src/Services/eventService.tsx
@@ -36,4 +36,17 @@ const createEvent = async () => {
   }
 };
 
+/**  Updates an exisiting event */
+export const updateEvent = async (
+  request: { id: string } & Partial<Omit<CommunityEvent, 'organizer' | 'id'>>,
+) => {
+  try {
+    const req = await axios.put(baseUrl, request);
+    const updatedEvent: CommunityEvent = req.data;
+    return updatedEvent;
+  } catch (e) {
+    console.error(e);
+  }
+};
+
 export default { getAll, getEvent, createEvent };


### PR DESCRIPTION
Created the updateEvent service on the frontend and made it require a the follow type as a parameter that will be set as a request to the backend

```typescript
const updateEvent (request : { id: string } & Partial<Omit<CommunityEvent, 'organizer' | 'id'>>)=> {...}

// where request is expected to be
{
  id: string;
  eventType?: EventType;
  ideaConfirmed?: boolean;
  date?: string;
  inPersonEvent: boolean;
  onlineEvent: boolean;
  notes?: string;
  venue?: string;
  venueContactName?: string;
  venueContactPhone?: string;
  venueContactEmail?: string;
  announcementPosted?: boolean;
  signUpFormSent?: boolean;
  numVolunteersNeeded?: number;
  volunteerRequestsSent?: boolean;
}

```

I did it this way in case we need to convert back some of the properties of Community Event to non-optional